### PR TITLE
Adjusting example of FireClient

### DIFF
--- a/pages/learn/studio/create/scripting/advanced/client-server-communication.md
+++ b/pages/learn/studio/create/scripting/advanced/client-server-communication.md
@@ -18,24 +18,25 @@ Here's an example:
 local myEvent = Event.new("MyEvent")
 
 function self:ClientAwake()
+  local localPlayer = client.localPlayer
   -- Fire the event on the server side
-  myEvent:Connect(function(player, message)
+  myEvent:Connect(function(message)
     -- Print the player's name and the message received from the server
-    print(player.name .. " says: " .. message) -- Output: Player1 says: Hello from server!
+    print(localPlayer.name .. ", server says: " .. message) -- Output: Player1 says: Hello from server!
   end)
 end
 
 function self:ServerAwake()
   -- Listen for the event on the server side
-  server.PlayerConnected:Connect(function(player)
+  scene.PlayerJoined:Connect(function(scene, player)
     local message = "Hello from server!"
     -- Fire the event on the client side and pass the message
-    myEvent:FireClient(message) -- No need to pass the player object when firing to client only
+    myEvent:FireClient(player, message) -- When firing to an individual client, you must pass a userdata object
   end)
 end
 ```
 
-In this example, the server listens for the `PlayerConnected` event and fires the `myEvent` event on the client side with the message "Hello from server!". The client receives the message and prints it along with the player's name.
+In this example, the server listens for the `PlayerJoined` event and fires the `myEvent` event on the client side with the message "Hello from server!". The client receives the message and prints it along with the player's name.
 
 ## Connection Methods
 


### PR DESCRIPTION
## Description

- What does this PR do? 

Makes changes to incorrect LUA example for FireClient in the Client-Server Communication.

1. Changed the FireClient to pass through the player userdata
2. Updated the server.PlayerConnected to scene.PlayerJoined
3. Removed "player" from the client event as it is not needed
3. Added localPlayer = client.localPlayer
4. Explicitly added "Server" on the print message

Example output:
<i>[Client]</i> xparadoxikallyx, server says: Hello from server!

- What is the context for making these changes? - 

1. FireClient stated that "No need to pass a player object when firing to client only" which is incorrect.
2. Server.PlayerConnected will not fire the PlayerConnected userdata because "There's a number of steps the client goes through when they first join, they first need to load the correct scene (handled by SceneLoader on the world prefab) then initialize it by adding players, instantiated objects, etc.  When PlayerConnected on the server is fired, if the script on the client that is connecting to that event is in the scene, it won't exist yet." - Azalearei 

